### PR TITLE
Updated package.json to add node-red entry

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,11 @@
   "keywords": [
     "node-red", "wit", "wit.ai", "Natural Language"
   ],
+  "node-red": {
+                "nodes": {
+                        "wit": "10-wit.js"
+                }
+  },
   "author": "efa200",
   "license": "ISC",
   "bugs": {


### PR DESCRIPTION
The node wasn't showing in my admin interface so I checked the package.json file and the node-red area was missing - http://nodered.org/docs/creating-nodes/packaging.html

I added that, re-installed the package and it shows in the admin interface now.
